### PR TITLE
Update build badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# jonallured.com
-
-[![Build Status](https://travis-ci.org/jonallured/jonallured.com.svg?branch=master)](https://travis-ci.org/jonallured/jonallured.com)
+# jonallured.com [![TravisCI][badge]][travisci]
 
 This is the source of [jonallured.com][site].
 
+[badge]: https://travis-ci.com/jonallured/jonallured.com.svg?branch=master
+[travisci]: https://travis-ci.com/github/jonallured/jonallured.com
 [site]: http://jonallured.com


### PR DESCRIPTION
Good news: now this badge is pointed at the right place.

Bad news: the build is broken. 😕 