### PR TITLE
Fix CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  NewCops: enable
+
+Style/Documentation:
+  Enabled: false

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 error_messages = {
   1 => 'Middleman failed to build site',
   2 => 'htmlproofer found errors'
@@ -5,6 +7,7 @@ error_messages = {
 
 system 'bundle exec rake'
 
-fail message if message = error_messages[$?.exitstatus]
+message = error_messages[$CHILD_STATUS.exitstatus]
+raise message if message
 
 commit_lint.check

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 ruby File.read('.tool-versions').split[1]
@@ -12,3 +14,4 @@ gem 'middleman-blog'
 gem 'middleman-google-analytics'
 gem 'rake'
 gem 'redcarpet'
+gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.1)
     backports (3.18.2)
     builder (3.2.4)
     claide (1.0.3)
@@ -140,6 +141,8 @@ GEM
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
     parallel (1.19.2)
+    parser (2.7.1.5)
+      ast (~> 2.4.1)
     public_suffix (4.0.6)
     rack (2.2.3)
     rainbow (3.0.0)
@@ -149,7 +152,20 @@ GEM
       ffi (~> 1.0)
     rchardet (1.8.0)
     redcarpet (3.5.0)
+    regexp_parser (1.8.1)
     rexml (3.2.4)
+    rubocop (0.92.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.5.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.7.1)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.10.1)
     sassc (2.4.0)
       ffi (~> 1.9)
     sawyer (0.8.2)
@@ -185,6 +201,7 @@ DEPENDENCIES
   middleman-google-analytics
   rake
   redcarpet
+  rubocop
 
 RUBY VERSION
    ruby 2.7.1p83

--- a/Rakefile
+++ b/Rakefile
@@ -17,9 +17,15 @@ task :build do
   exit 1 unless system 'bundle exec middleman build'
 end
 
-desc 'Verify generated HTML'
-task :verify_html do
-  options = { assume_extension: true }
+desc 'Check generated HTML'
+task :check_html do
+  options = { assume_extension: true, disable_external: true }
+  HTMLProofer.check_directory('build', options).run
+end
+
+desc 'Check external links'
+task :check_links do
+  options = { assume_extension: true, checks_to_ignore: %w[ImageCheck ScriptCheck], external_only: true }
   HTMLProofer.check_directory('build', options).run
 end
 
@@ -52,4 +58,4 @@ end
 desc 'Run RuboCop'
 RuboCop::RakeTask.new(:rubocop)
 
-task default: %i[rubocop build verify_html]
+task default: %i[rubocop build check_html]

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require 'nokogiri'
 require 'yaml'
 require 'dotenv'
 require 'rubocop/rake_task'
+require 'html-proofer'
 
 require './lib/feed'
 
@@ -18,7 +19,8 @@ end
 
 desc 'Verify generated HTML'
 task :verify_html do
-  exit 2 unless system 'bundle exec htmlproofer ./build'
+  options = { assume_extension: true }
+  HTMLProofer.check_directory('build', options).run
 end
 
 desc 'Deploy site'

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,11 @@
+# frozen_string_literal: true
+
 require 'date'
 require 'active_support'
 require 'nokogiri'
 require 'yaml'
 require 'dotenv'
+require 'rubocop/rake_task'
 
 require './lib/feed'
 
@@ -26,7 +29,7 @@ end
 
 desc 'Parse Feedbin Subscription File'
 task :parse_subs do
-  unless File.exists? './subscriptions.xml'
+  unless File.exist? './subscriptions.xml'
     puts "can't find subscriptions.xml file!"
     exit 1
   end
@@ -44,4 +47,7 @@ task :parse_subs do
   File.write 'data/feeds.yml', yaml
 end
 
-task default: [:build, :verify_html]
+desc 'Run RuboCop'
+RuboCop::RakeTask.new(:rubocop)
+
+task default: %i[rubocop build verify_html]

--- a/Rakefile
+++ b/Rakefile
@@ -3,26 +3,10 @@ require 'active_support'
 require 'nokogiri'
 require 'yaml'
 require 'dotenv'
+
+require './lib/feed'
+
 Dotenv.load
-
-class Feed
-  include Comparable
-
-  attr_reader :name, :url
-
-  def initialize(name, url)
-    @name = name
-    @url = url
-  end
-
-  def <=>(other)
-    self.name.upcase <=> other.name.upcase
-  end
-
-  def to_hash
-    { name: name, url: url }
-  end
-end
 
 desc 'Build Middleman site'
 task :build do

--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 set :layout, :default
 
 page 'atom.xml', layout: false

--- a/lib/feed.rb
+++ b/lib/feed.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Feed
+  include Comparable
+
+  attr_reader :name, :url
+
+  def initialize(name, url)
+    @name = name
+    @url = url
+  end
+
+  def <=>(other)
+    name.upcase <=> other.name.upcase
+  end
+
+  def to_hash
+    { name: name, url: url }
+  end
+end

--- a/source/atom.xml.builder
+++ b/source/atom.xml.builder
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 xml.instruct!
 xml.feed 'xmlns' => 'http://www.w3.org/2005/Atom' do
   site_url = 'http://jonallured.com'


### PR DESCRIPTION
CI has been busted and I finally decided to take a closer look at HTML proofer to figure out how I wanted to deal with this. What I've done here is separate the checking of the built HTML from the checking of external links. I'll check the former on CI but not the latter. Or well, maybe I'll make a cron run on Travis to check for link rot, but in the future, not now.

I also added RuboCop because I was tired of seeing warnings in Vim.