### PR TITLE
Only build main branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: ruby
 rvm:
   - 2.7.1
+branches:
+  only:
+    - main


### PR DESCRIPTION
When I went to simplify my Travis setup I removed this setting, but I changed my mind. This is worth adding because it means PRs only build once rather than having to wait for the branch to be built and _then_ get the PR to be built.