### PR TITLE
Add update script

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+git ensure-main
+
+labels="automerge,dependencies"
+message=$(cat <<"END"
+Dependency Updates
+
+This commit updates project dependencies like this:
+
+```
+$ bundle update
+```
+
+It was automatically created with this script:
+
+```
+$ ./bin/update
+```
+END
+)
+
+git fetch --all --quiet
+git checkout -b updates
+bundle update
+bundle exec rake
+git add .
+git commit --message "$message"
+git push origin updates
+gh pr create --fill --label "$labels"

--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+Haml::TempleEngine.disable_option_validator!
+
 set :layout, :default
 
 page 'atom.xml', layout: false


### PR DESCRIPTION
This PR adds my typical update script and then I also added a config line to suppress HAML warnings because apparently the Middleman team doesn't care about them:

https://github.com/middleman/middleman/issues/2113#issuecomment-471365549

Which makes me sad, but at least now I don't have these warnings polluting my build feedback.