### PR TITLE
Use sudo to install rsync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - run:
           name: Installing rsync
-          command: apt-get update && apt-get install -y rsync
+          command: sudo apt-get update && sudo apt-get install -y rsync
 
       - add_ssh_keys
 


### PR DESCRIPTION
I don't really understand why this needs sudo while other config do not, but let's see how it goes.