### PR TITLE
Remove newlines from cleaned summaries

### DIFF
--- a/helpers/custom_helpers.rb
+++ b/helpers/custom_helpers.rb
@@ -2,6 +2,6 @@
 
 module CustomHelpers
   def clean_summary(article)
-    article.summary.gsub(%r{</?[^>]*>}, '')
+    article.summary.gsub(%r{</?[^>]*>}, '').gsub("\n", ' ')
   end
 end


### PR DESCRIPTION
I realized that newlines were probably goofing this up.