### PR TITLE
Specify twitter card type

### DIFF
--- a/source/layouts/post.html.haml
+++ b/source/layouts/post.html.haml
@@ -1,4 +1,5 @@
 - content_for :head do
+  %meta{ name: "twitter:card", content: 'summary_large_image' }
   %meta{ property: "og:description", content: clean_summary(current_article) }
   %meta{ property: "og:image", content: "/images/headshot.png" }
   %meta{ property: "og:title", content: current_article.title }


### PR DESCRIPTION
I _think_ this isn't working just because you have to include this `twitter:card` tag for it to do anything.