### PR TITLE
Add a script and template for weekly review posts

### DIFF
--- a/bin/new_week_review_article
+++ b/bin/new_week_review_article
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+week_number=$(date +"%-V")
+year=$(date +"%Y")
+title="Week in Review: Week ${week_number}, ${year}"
+
+cp week_review_template.erb new_article_template.erb
+./bin/new_article $title
+git checkout new_article_template.erb

--- a/week_review_template.erb
+++ b/week_review_template.erb
@@ -1,0 +1,17 @@
+---
+favorite: false
+id: REPLACE
+title: "<%= @title %>"
+---
+
+This is the intro part.
+
+## Highlights
+
+* worked 40:00, no PTO
+* published PT
+* published Artsy Engineering Radio
+* published blog posts
+* shipped features
+
+[gh-activity]: https://github.com/search?s=created&o=desc&q=author:jonallured+created:2021-02-14..2021-02-20


### PR DESCRIPTION
It's a bit nutty that I have to do this but unless I'm missing something there's no support in the middleman article command to specify a template. That means whichever template you've specified in your middleman config file will be used. I created a general purpose template so that's fine, but I want something a bit different when it comes to these weekly review posts.

So my approach to this problem is to author a second template and then copy over the general one, create the weekly review post and then checkout that change to the general template. Goofy I know but what are ya gonna do?!

I'll also note that I poked at `date` to figure out how to grab the current week number and year. Turns out `V` is the iso week number so that's perfect and then I found that you can prefix with `-` to disable zero-padding behavior in `date` so that's why that's there.