### PR TITLE
Add Bluesky to sidebar

### DIFF
--- a/data/sidebar.yml
+++ b/data/sidebar.yml
@@ -29,6 +29,8 @@
 
 - title: Elsewhere
   links:
+    - text: Bluesky
+      url: https://bsky.app/profile/jonallured.com
     - text: GitHub
       url: https://github.com/jonallured
     - text: Mastodon


### PR DESCRIPTION
Lil update for adding my Bluesky account to the Elsewhere section of the sidebar.