### PR TITLE
Add ImageMagick to GitHub deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Scan server keys
         run: ssh-keyscan www.jonallured.com >> ~/.ssh/known_hosts
       - uses: actions/checkout@v2
+      - uses: mfinelli/setup-imagemagick@v7
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true


### PR DESCRIPTION
Well #135 didn't work - there was an error installing RMagick because ImageMagick is not installed. Errors here:

https://github.com/jonallured/jonallured.com/actions/runs/18475800382/job/52639920908

And so my approach to solving the issue is to use a GitHub action from the community to install it. As before I pretty much have to just merge and run and hope it works. 🤞 